### PR TITLE
Fix space escaping in paths dragged onto the icon

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -192,7 +192,7 @@ export function openFile (path) {
             // We need to use 'php-escape-shell' property this way
             // until this eslint issue will be fixed:
             // https://github.com/eslint/eslint/issues/6755
-            let command = shellEscape.php_escapeshellcmd(path);
+            let command = shellEscape.php_escapeshellcmd(path).replace(/ /g, '\\ ');
             if (stats.isDirectory()) {
               command = `cd ${command}\n`;
             } else if (stats.isFile() && isExecutable(stats)) {


### PR DESCRIPTION
Add a fix for the space issue in https://github.com/zeit/hyperterm/pull/329
